### PR TITLE
Remove legacy components - fixes error handling

### DIFF
--- a/oak_cli/commands/plugins/flops/flops.SLA.json
+++ b/oak_cli/commands/plugins/flops/flops.SLA.json
@@ -1,13 +1,16 @@
 {
     "verbose": true,
     "customerID": "Admin",
-    "applicationID": "",
-    "code": "https://github.com/Malyuk-A/mlflower-test-a",
-    "memory": 100,
-    "vcpus": 1,
-    "vgpus": 0,
-    "vtpus": 0,
-    "bandwidth_in": 0,
-    "bandwidth_out": 0,
-    "storage": 0
+    "ml_repo_url": "https://github.com/Malyuk-A/mlflower-test-a",
+    "training_configuration": {
+        "training_rounds": 1,
+        "min_available_clients":2,
+        "min_fit_clients": 2,
+        "min_evaluate_clients": 2
+    },
+    "resource_constraints": {
+        "memory": 100,
+        "vcpus": 1,
+        "storage": 0
+    }
 }

--- a/oak_cli/utils/api/custom_requests.py
+++ b/oak_cli/utils/api/custom_requests.py
@@ -95,8 +95,7 @@ class CustomRequest:
         error_msg += self._create_failure_msg()
 
         raise OakCLIException(
-            flops_exception_type=self.aux.flops_exception_type,
+            oak_cli_exception_type=self.aux.oak_cli_exception_type,
             text=error_msg,
             http_status=self.response.status if self.response else None,
-            flops_project_id=self.aux.flops_project_id,
         )

--- a/oak_cli/utils/exceptions/main.py
+++ b/oak_cli/utils/exceptions/main.py
@@ -13,5 +13,5 @@ class OakCLIException(Exception):
 
     message: str = field(init=False)
 
-    def model_post_init(self, _) -> None:
+    def __post_init__(self) -> None:
         self.message = f"'{self.oak_cli_exception_type}' exception occured: {self.text}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "oak_cli"
-version = "0.2.8"
+version = "0.2.11"
 description = ""
 authors = ["Alexander Malyuk <malyuk.alexander1999@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
There were a few legacy components left in the error handling code, that were leading to exceptions themselves.
Now this is fixed and error handling works as it should again.

The latest version is now available here: https://pypi.org/project/oak-cli/0.2.11/